### PR TITLE
created blueprint for wordcloud route

### DIFF
--- a/api.cybode.com/app.py
+++ b/api.cybode.com/app.py
@@ -159,21 +159,7 @@ def sentiment():
 
 
 #highlight key segments of the news article [status - 200]
-@app.route('/wordcloud')
-def plotly_wordcloud2():
-    url = request.args['url']
-    goose = Goose()
-    articles = goose.extract(url)
-    text = articles.cleaned_text
-    wordcloud = WordCloud(width=1280, height=853, margin=0,
-                      colormap='Blues').generate(text)
-    wordcloud.to_file("./wordcloud.png")
-    plt.imshow(wordcloud, interpolation='bilinear')
-    plt.axis('off')
-    plt.margins(x=0, y=0)
 
-    return send_file("./wordcloud.png", mimetype='image/png')
-    
 
 #check the authentic source of the news article [status - 200]
 @app.route('/authenticity')
@@ -230,6 +216,9 @@ app.register_blueprint(get_propaganda)
 
 from routes.news.summary import get_summary
 app.register_blueprint(get_summary)
+
+from routes.news.summary import get_wordcloud
+app.register_blueprint(get_wordcloud)
 
 #to resolve circular imports
 app.config.from_object(Config)

--- a/api.cybode.com/routes/news/wordcloud.py
+++ b/api.cybode.com/routes/news/wordcloud.py
@@ -1,0 +1,34 @@
+from flask import send_file, jsonify, request, Blueprint
+from goose3 import Goose
+import requests
+from app import app
+from app import headers
+from wordcloud import WordCloud
+import matplotlib.pyplot as plt
+
+
+API_URL = "https://api-inference.huggingface.co/models/valurank/distilroberta-propaganda-2class"
+
+
+get_wordcloud = Blueprint('get_wordcloud', __name__)
+
+
+def query(payload):
+	response = requests.post(API_URL, headers=headers, json=payload)
+	return response.json()
+
+@get_wordcloud.route('/wordcloud')
+def plotly_wordcloud2():
+    url = request.args['url']
+    goose = Goose()
+    articles = goose.extract(url)
+    text = articles.cleaned_text
+    wordcloud = WordCloud(width=1280, height=853, margin=0,
+                      colormap='Blues').generate(text)
+    wordcloud.to_file("./wordcloud.png")
+    plt.imshow(wordcloud, interpolation='bilinear')
+    plt.axis('off')
+    plt.margins(x=0, y=0)
+
+    return send_file("./wordcloud.png", mimetype='image/png')
+    


### PR DESCRIPTION
## Title :
Ceate a blueprint for the wordcloud route and register to the app

## Issue no : 
Fixes #13
## Description
a new word cloud generation route in Flask by creating "wordcloud.py" and registering it in "app.py" using a Blueprint.

## Screenshots (if applicable)
<!--![Screenshot](url-to-screenshot)-->

## Checklist
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/tcet-opensource/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read and followed the **Contributing Guidelines**